### PR TITLE
Automated dotnet-format update (#502)

### DIFF
--- a/src/Controls/samples/Controls.Sample/Pages/MainPage.cs
+++ b/src/Controls/samples/Controls.Sample/Pages/MainPage.cs
@@ -36,7 +36,7 @@ namespace Maui.Controls.Sample.Pages
 			var horizontalStack = new HorizontalStackLayout() { Spacing = 2, BackgroundColor = Color.CornflowerBlue };
 
 			verticalStack.Add(new Label { Text = " ", Padding = new Thickness(10) });
-      
+
 			var label = new Label { Text = "centered text", BackgroundColor = Color.Fuchsia, HorizontalTextAlignment = TextAlignment.End };
 			label.Margin = new Thickness(15, 10, 20, 15);
 

--- a/src/Core/src/Handlers/Button/ButtonHandler.Android.cs
+++ b/src/Core/src/Handlers/Button/ButtonHandler.Android.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Maui.Handlers
 			handler.TypedNativeView?.UpdateFont(button, fontManager);
 		}
 
-		public static void MapPadding(ButtonHandler handler, IButton button) 
+		public static void MapPadding(ButtonHandler handler, IButton button)
 		{
 			handler.TypedNativeView?.UpdatePadding(button);
 		}

--- a/src/Core/src/Handlers/Entry/EntryHandler.iOS.cs
+++ b/src/Core/src/Handlers/Entry/EntryHandler.iOS.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Maui.Handlers
 			if (mauiText != nativeText)
 				VirtualView.Text = nativeText;
 		}
-		
+
 		public static void MapFont(EntryHandler handler, IEntry entry)
 		{
 			var services = App.Current?.Services

--- a/src/Core/src/Handlers/Label/LabelHandler.Standard.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.Standard.cs
@@ -14,6 +14,6 @@ namespace Microsoft.Maui.Handlers
 		public static void MapLineBreakMode(LabelHandler handler, ILabel label) { }
 		public static void MapTextDecorations(LabelHandler handler, ILabel label) { }
 		public static void MapMaxLines(IViewHandler handler, ILabel label) { }
-		public static void MapPadding(LabelHandler handler, ILabel label) {	}
+		public static void MapPadding(LabelHandler handler, ILabel label) { }
 	}
 }

--- a/src/Core/src/Platform/Android/ButtonExtensions.cs
+++ b/src/Core/src/Platform/Android/ButtonExtensions.cs
@@ -1,5 +1,5 @@
-using Android.Util;
 using Android.Content.Res;
+using Android.Util;
 using AndroidX.AppCompat.Widget;
 using XColor = Microsoft.Maui.Color;
 

--- a/src/Core/src/Platform/Android/EntryExtensions.cs
+++ b/src/Core/src/Platform/Android/EntryExtensions.cs
@@ -1,6 +1,6 @@
-﻿using Android.Util;
-using Android.Content.Res;
+﻿using Android.Content.Res;
 using Android.Text;
+using Android.Util;
 using AndroidX.AppCompat.Widget;
 
 namespace Microsoft.Maui
@@ -85,7 +85,7 @@ namespace Microsoft.Maui
 			editText.FocusableInTouchMode = isEditable;
 			editText.Focusable = isEditable;
 		}
-		
+
 		public static void UpdateFont(this AppCompatEditText editText, IEntry entry, IFontManager fontManager)
 		{
 			var font = entry.Font;

--- a/src/Core/src/Platform/iOS/EntryExtensions.cs
+++ b/src/Core/src/Platform/iOS/EntryExtensions.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Maui
 		{
 			textField.UserInteractionEnabled = !entry.IsReadOnly;
 		}
-			
+
 		public static void UpdateFont(this UITextField textField, IEntry entry, IFontManager fontManager)
 		{
 			var uiFont = fontManager.GetFont(entry.Font);

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Android.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.Android.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Maui.DeviceTests
 
 			return !editText.Focusable && !editText.FocusableInTouchMode;
 		}
-		
+
 		double GetNativeUnscaledFontSize(EntryHandler entryHandler)
 		{
 			var textView = GetNativeEntry(entryHandler);

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.cs
@@ -163,8 +163,8 @@ namespace Microsoft.Maui.DeviceTests
 				GetNativeIsReadOnly,
 				setValue,
 				unsetValue);
-		}		
-				
+		}
+
 		[Theory(DisplayName = "Font Size Initializes Correctly")]
 		[InlineData(1)]
 		[InlineData(10)]
@@ -233,7 +233,7 @@ namespace Microsoft.Maui.DeviceTests
 				Assert.Equal(initialText, e.OldValue);
 				Assert.Equal(newText ?? string.Empty, e.NewValue);
 			};
-		
+
 			await SetValueAsync(entry, newText, SetNativeText);
 
 			if (eventExpected)

--- a/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.iOS.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Entry/EntryHandlerTests.iOS.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Maui.DeviceTests
 
 		bool GetNativeIsReadOnly(EntryHandler entryHandler) =>
 			!GetNativeEntry(entryHandler).UserInteractionEnabled;
-			
+
 		double GetNativeUnscaledFontSize(EntryHandler entryHandler) =>
 			GetNativeEntry(entryHandler).Font.PointSize;
 

--- a/src/Core/tests/DeviceTests/Stubs/ButtonStub.cs
+++ b/src/Core/tests/DeviceTests/Stubs/ButtonStub.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Maui.DeviceTests.Stubs
 		public double CharacterSpacing { get; set; }
 
 		public Font Font { get; set; }
-		
+
 		public Thickness Padding { get; set; }
 
 		public event EventHandler Pressed;

--- a/src/Core/tests/DeviceTests/TestCategory.cs
+++ b/src/Core/tests/DeviceTests/TestCategory.cs
@@ -7,7 +7,7 @@
 		public const string Entry = "Entry";
 		public const string Label = "Label";
 		public const string Layout = "Layout";
-    public const string SearchBar = "SearchBar";
+		public const string SearchBar = "SearchBar";
 		public const string Slider = "Slider";
 		public const string Switch = "Switch";
 		public const string View = "View";


### PR DESCRIPTION
Co-authored-by: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>



<!-- 

We are currently only accepting Pull Requests for .NET MAUI issues in our [Handler Property Backlog](https://github.com/dotnet/maui/projects/4). We will continue to update this repository over the next couple of months as we begin to accept more types of PRs.

Before you submit this PR, make sure you're building on and targeting the right branch!
     - If this is an enhancement or contains API changes or breaking changes, target main.
          - If the issue you're working on has a milestone, target the corresponding branch.
          - If this is a bug fix, target the branch of the latest stable version (unless the bug is only in a prerelease or main, of course!).
               See [Contributing](https://github.com/dotnet/maui/blob/main/.github/CONTRIBUTING.md) for more tips!

```
 PLEASE DELETE THE ALL THESE COMMENTS BEFORE SUBMITTING! THANKS!!!
```
 -->
### Description of Change ###

<!-- Please use the format "Implements #xxxx" for the issue this PR addresses -->

Implements #

### Additions made ###
<!-- List all the additions made here, example:

 - Adds `Thickness Padding { get; }` to the `ILabel` interface
- Adds Padding property map to LabelHandler
- Adds Padding mapping methods to LabelHandler for Android and iOS
- Adds extension methods to apply Padding on Android/iOS
- Adds UILabel subclass MauiLabel (to support Padding, since UILabel doesn't by default)
- Adds DeviceTests for initial Padding values on iOS and Android

 -->

* Adds 

### PR Checklist ###

<!-- See our [Handler Property PR Guidelines](https://github.com/dotnet/maui/wiki/Handler-Property-PR-Guidelines) for more tips -->

- [ ] Targets the correct branch 
- [ ] Tests are passing (or failures are unrelated)
- [ ] Targets a single property for a single control (or intertwined few properties)
- [ ] Adds the property to the appropriate interface
- [ ] Avoids any changes not essential to the handler property
- [ ] Adds the mapping to the PropertyMapper in the handler
- [ ] Adds the mapping method to the Android, iOS, and Standard aspects of the handler
- [ ] Implements the actual property updates (usually in extension methods in the Platform section of Core)
- [ ] Tags ported renderer methods with [PortHandler]
- [ ] Adds an example of the property to the sample project (MainPage)
- [ ] Adds the property to the stub class
- [ ] Implements basic property tests in DeviceTests